### PR TITLE
fix: 「すべて表示」リンクのページ遷移を修正

### DIFF
--- a/goannai/index.html
+++ b/goannai/index.html
@@ -146,7 +146,7 @@
     </section>
 </main>
 
-<div id="#news-page" class="page-content" style="display: none;">
+<div id="news-page" class="page-content" style="display: none;">
     <main>
         <!-- タイトル -->
         <section class="ttl">

--- a/goannai/js/main.js
+++ b/goannai/js/main.js
@@ -39,7 +39,7 @@ if (pageTopButton) {
 
 // Page switching logic
 $(function() {
-    const mainContent = $('main').first();
+    const mainContent = $('body > main').first();
     const pageContents = $('.page-content');
 
     function showPage(targetId) {
@@ -49,7 +49,7 @@ $(function() {
         } else {
             mainContent.hide();
             pageContents.hide();
-            $(targetId).show();
+            $(targetId).css('display', 'block');
         }
         window.scrollTo(0, 0);
     }


### PR DESCRIPTION
お知らせセクションの「すべて表示」リンクは、ターゲット要素のIDが無効（`id="#news-page"`）だったため機能していませんでした。

このコミットでは、`goannai/index.html`のIDを修正します。

さらに、`goannai/js/main.js`のJavaScriptをより堅牢にするために、以下の変更を加えました。
- メインコンテンツのセレクタをより具体的に（`body > main`）し、ネストされた`<main>`要素が誤って非表示にされるのを防ぎます。
- テスト環境で`.show()`が確実に機能しなかったため、要素を確実に表示するために`.css('display', 'block')`に置き換えました。