### PR TITLE
fix: Adjust vertical padding of company box

### DIFF
--- a/newwebpanh/common/css/style.css
+++ b/newwebpanh/common/css/style.css
@@ -209,7 +209,7 @@ header h1 img{
             text-align: center; /* テキストを中央揃えに */
             transition: transform 0.3s, box-shadow 0.3s; /* ホバー時のアニメーション効果 */
             width: 200px; /* ボックスの幅を固定 */
-            min-height: 150px; /* ボックスの最小の高さを設定 */
+            min-height: 130px; /* ボックスの最小の高さを設定 */
         }
 
         /* マウスを乗せた時のスタイル */


### PR DESCRIPTION
Based on user feedback, the company box appeared too tall. This commit reduces the `min-height` of the `.box-link` element to decrease its vertical size and make the padding look more balanced.