### PR TITLE
refactor: Remove min-height from company box

### DIFF
--- a/newwebpanh/common/css/style.css
+++ b/newwebpanh/common/css/style.css
@@ -209,7 +209,6 @@ header h1 img{
             text-align: center; /* テキストを中央揃えに */
             transition: transform 0.3s, box-shadow 0.3s; /* ホバー時のアニメーション効果 */
             width: 200px; /* ボックスの幅を固定 */
-            min-height: 130px; /* ボックスの最小の高さを設定 */
         }
 
         /* マウスを乗せた時のスタイル */


### PR DESCRIPTION
To better match the user's desired vertical size, this commit removes the `min-height` property from the `.box-link` element. This allows the box's height to be determined by its content and padding, resulting in a more compact and dynamically sized component.